### PR TITLE
Shorten the script path to webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "lint": "standard src/**/*.js",
-    "build": "./node_modules/.bin/webpack -p",
+    "build": "webpack -p",
     "deploy": "./deploy-ghpages.sh",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
npm scripts automatically look in `./node_modules/.bin/` so we don't need to include that in the path.